### PR TITLE
Creating PR to track Chrome tabCapture timing issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+recorder-extension/
 data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
         lsb-release xdg-utils wget gosu gpg curl \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list \
-    && apt update && apt install -y google-chrome-stable \
+    && apt-get update && apt-get install -y google-chrome-stable \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /home/node/Downloads \

--- a/README.md
+++ b/README.md
@@ -1,37 +1,74 @@
 # Puppetcam
 
-Example to export chrome tab as a video
+Create screencast of a website
 
+## Examples
 
-1. Exported videos are stored in Downloads folder
-2. Specify bitrate to control quality of the exported video by adjusting `videoBitsPerSecond` property in `background.js`
+### Record given length video from website
 
+```sh
+docker run -v "${PWD}/data:/home/node/Downloads" apicore/puppetcam https://tobiasahlin.com/spinkit/ -l 10000
+```
+
+The output will be a 10 second long full HD video saved as `./data/video.webm`.
+
+### Record video from website using webside-side triggering
+
+```sh
+docker run -v "${PWD}/data:/home/node/Downloads" apicore/puppetcam https://site-triggered.example/ -t -l 10000
+```
+
+The recording is started when the `window.triggerRenderer` variable on the website becomes `true` and it is stopped when the same variable becomes `false` again. This option can be used to control the recording from the website itself. In this case the `--length` parameter is only used to set a sensible timeout. The output will be a full HD video saved as `./data/video.webm`.
+
+## Command line arguments
+
+```
+export.js <url>
+
+Record a video from a given url
+
+Positionals:
+  url  URL to record the video from                                     [string]
+
+Options:
+      --help           Show help                                       [boolean]
+      --version        Show version number                             [boolean]
+  -o, --output         Output path    [string] [default: ~/Downloads/video.webm]
+  -l, --length         Video length in milliseconds     [number] [default: 5000]
+  -w, --width          Video width                      [number] [default: 1920]
+  -h, --height         Video height                     [number] [default: 1080]
+  -t, --trigger        Use trigger from website       [boolean] [default: false]
+  -s, --start-timeout  Start trigger timeout          [number] [default: 120000]
+  -e, --end-timeout    End trigger timeout              [number] [default: 5000]
+```
+
+## Running without Docker
 
 ### Dependencies
 
 1. xvfb
-2. npm modules listed in package.json
+2. chrome browser
+3. nodejs
+4. npm modules listed in package.json
+5. up-to-date git submodules
 
-### Docker
+### Preparation
 
 ```sh
-docker build -t puppetcam:standalone .
-docker run -v "${PWD}/data:/home/node/Downloads" puppetcam:standalone http://tobiasahlin.com/spinkit/ spinner.webm
+npm install
+npm run install-extension
 ```
 
 ### Usage
 
+Use the same way as the dockerized version. A few examples:
+
 ```sh
-npm install
-node export.js http://tobiasahlin.com/spinkit/ spinner.webm
+node export.js https://tobiasahlin.com/spinkit/ -l 10000 # Outputs ~/Downloads/video.webm
+node export.js https://tobiasahlin.com/spinkit/ -o spinkit.webm # Outputs ./spinkit.webm
 ```
 
+## Credits
 
-Thanks to [@cretz](https://github.com/cretz) for helping with automatic tab selection and avoiding the permission dialog
-
-#### Motivation
-
-Was looking for a method to export a video of user actions rendered using our custom player used in [uxlens](https://uxlens.com). Export has to happen on a server in an automated fashion and hence the usage of xvfb.
-
-#### Sample video
-[![Puppetcam](https://img.youtube.com/vi/f7Vdd0ExWiY/0.jpg)](https://www.youtube.com/watch?v=f7Vdd0ExWiY "Puppetcam")
+* Thanks to [@muralikg](https://github.com/muralikg) for the original puppetcam idea.
+* Thanks to [@muaz-khan](https://github.com/muaz-khan) for his [screen-recording](https://github.com/muaz-khan/Chrome-Extensions/tree/master/screen-recording) chrome extension.

--- a/export.js
+++ b/export.js
@@ -91,6 +91,9 @@ async function main() {
         });
       }, "message");
 
+      console.log("Waiting for page signal...")
+      await page.waitForFunction('window.triggerRenderer == true')
+
       console.log('Starting recording...')
       await page.evaluate((width, height) => {
           window.recorder = new RecordRTC_Extension();

--- a/export.js
+++ b/export.js
@@ -109,8 +109,12 @@ async function main() {
       }, width, height);
 
       console.log("Waiting for stop signal from page...")
-      await page.waitForFunction('window.triggerRenderer == false', { timeout: length + 5000 })
-      console.log('Got stop signal after', Date.now() - record_start, 'ms')
+      try {
+        await page.waitForFunction('window.triggerRenderer == false', { timeout: length + 5000 })
+        console.log('Got stop signal after', Date.now() - record_start, 'ms')
+      } catch (e) {
+        console.log('Stop signal timed out after', Date.now() - record_start, 'ms')
+      }
 
       await page.evaluate(() => {
         window.recorder.stopRecording();

--- a/export.js
+++ b/export.js
@@ -4,7 +4,7 @@ const Xvfb = require('xvfb');
 const argv = require('yargs')
   .command('$0 <url>', 'Record a video from a given url and save it to the Downloads folder', (yargs) => yargs
     .positional('url', { describe: 'URL to record the video from', type: 'string' })
-    .option('o', { alias: 'output', demandOption: false, default: 'video.webm', describe: 'Output filename', type: 'string' })
+    .option('o', { alias: 'output', demandOption: false, default: 'video.mp4', describe: 'Output filename', type: 'string' })
     .option('l', { alias: 'length', demandOption: false, default: 5000, describe: 'Video length in milliseconds', type: 'number' })
     .option('w', { alias: 'width', demandOption: false, default: 1920, describe: 'Video width', type: 'number' })
     .option('h', { alias: 'height', demandOption: false, default: 1080, describe: 'Video height', type: 'number' })
@@ -129,6 +129,7 @@ async function main() {
             sendBlobInMessage: false,
             saveFileAsDownload: true,
             saveFileName: filename,
+            videoCodec: "H264",
           });
       }, argv.width, argv.height, argv.output);
 

--- a/export.js
+++ b/export.js
@@ -105,7 +105,7 @@ async function main() {
       }, width, height);
 
       console.log("Waiting for stop signal from page...")
-      await page.waitForFunction('window.triggerRenderer == false', { timeout: length + 2000 })
+      await page.waitForFunction('window.triggerRenderer == false', { timeout: length + 5000 })
       await page.evaluate(() => {
         window.recorder.stopRecording();
       });

--- a/export.js
+++ b/export.js
@@ -148,6 +148,7 @@ async function main() {
       }
     })
 
+    console.log(JSON.stringify(video_data))
     const fileSize = video_data.size/1024/1024;
     console.error('File saved to', video_data.path, '(size:', fileSize.toFixed(2), 'MB)')
 

--- a/export.js
+++ b/export.js
@@ -59,6 +59,7 @@ async function main() {
     const browser = await puppeteer.launch(options)
     const pages = await browser.pages()
     const page = pages[0]
+    let command_start
     let record_start
 
     const video_data = await new Promise(async (resolve) => {
@@ -71,7 +72,7 @@ async function main() {
         }
 
         if (e.data.startedRecording == true) {
-          console.log('Recording started, it will take', length/1000, 'seconds')
+          console.log('Recording started in', Date.now() - command_start,'ms, it will take', length/1000, 'seconds')
           record_start = Date.now()
         }
 
@@ -91,9 +92,12 @@ async function main() {
         window.recorder = new RecordRTC_Extension();
       });
 
+      command_start = Date.now();
       console.log("Waiting for start signal from page...")
       await page.waitForFunction('window.triggerRenderer == true', { timeout: 120000 })
+      console.log('Preloading took', Date.now() - command_start, 'ms')
 
+      command_start = Date.now();
       console.log('Starting recording...')
       await page.evaluate((width, height) => {
           window.recorder.startRecording({
@@ -106,6 +110,8 @@ async function main() {
 
       console.log("Waiting for stop signal from page...")
       await page.waitForFunction('window.triggerRenderer == false', { timeout: length + 5000 })
+      console.log('Got stop signal after', Date.now() - record_start, 'ms')
+
       await page.evaluate(() => {
         window.recorder.stopRecording();
       });

--- a/export.js
+++ b/export.js
@@ -19,11 +19,11 @@ async function main() {
     const width_screen = argv.width + 1
     const height_screen = argv.height + 1 + 44
 
-    console.log('url: ' + argv.url)
-    console.log('filename: ' + argv.output)
-    console.log('length: ' + argv.length + ' ms')
-    console.log('screen resolution: ' + width_screen + 'x' + height_screen)
-    console.log('video resolution: ' + argv.width + 'x' + argv.height)
+    console.error('url: ' + argv.url)
+    console.error('filename: ' + argv.output)
+    console.error('length: ' + argv.length + ' ms')
+    console.error('screen resolution: ' + width_screen + 'x' + height_screen)
+    console.error('video resolution: ' + argv.width + 'x' + argv.height)
 
     xvfb = new Xvfb({
       silent: true,
@@ -60,7 +60,7 @@ async function main() {
       dumpio: false, /* change to true for chrome debugging */
     }
 
-    console.log('Launching browser')
+    console.error('Launching browser')
     xvfb.startSync()
     const browser = await puppeteer.launch(options)
     const pages = await browser.pages()
@@ -78,7 +78,7 @@ async function main() {
         }
 
         if (e.data.startedRecording == true) {
-          console.log('Recording started in', Date.now() - command_start, 'ms, it will take', argv.length, 'ms')
+          console.error('Recording started in', Date.now() - command_start, 'ms, it will take', argv.length, 'ms')
           record_start = Date.now()
           if (!argv.trigger) {
             page.evaluate(time_ms => {
@@ -88,7 +88,7 @@ async function main() {
         }
 
         if (e.data.stoppedRecording == true) {
-          console.log('Recording finished, it took', Date.now() - record_start, 'ms')
+          console.error('Recording finished, it took', Date.now() - record_start, 'ms')
           resolve({
             path: e.data.downloadPath,
             size: e.data.downloadSize,
@@ -96,7 +96,7 @@ async function main() {
         }
 
         if (e.data.failedRecording == true) {
-          console.log('Recording failed after', Date.now() - record_start, 'ms')
+          console.error('Recording failed after', Date.now() - record_start, 'ms')
           reject()
         }
       });
@@ -113,13 +113,13 @@ async function main() {
 
       if (argv.trigger) {
         command_start = Date.now();
-        console.log("Waiting for start signal from page...")
+        console.error("Waiting for start signal from page...")
         await page.waitForFunction('window.triggerRenderer == true', { timeout: argv.startTimeout })
-        console.log('Preloading took', Date.now() - command_start, 'ms')
+        console.error('Preloading took', Date.now() - command_start, 'ms')
       }
 
       command_start = Date.now();
-      console.log('Starting recording...')
+      console.error('Starting recording...')
       await page.evaluate((width, height, filename) => {
           window.recorder.startRecording({
             enableTabCaptureAPI: true,
@@ -134,12 +134,12 @@ async function main() {
       }, argv.width, argv.height, argv.output);
 
       if (argv.trigger) {
-        console.log("Waiting for stop signal from page...")
+        console.error("Waiting for stop signal from page...")
         try {
           await page.waitForFunction('window.triggerRenderer == false', { timeout: argv.length + argv.endTimeout })
-          console.log('Got stop signal after', Date.now() - record_start, 'ms')
+          console.error('Got stop signal after', Date.now() - record_start, 'ms')
         } catch (e) {
-          console.log('Stop signal timed out after', Date.now() - record_start, 'ms')
+          console.error('Stop signal timed out after', Date.now() - record_start, 'ms')
         }
 
         await page.evaluate(() => {
@@ -149,9 +149,9 @@ async function main() {
     })
 
     const fileSize = video_data.size/1024/1024;
-    console.log('File saved to', video_data.path, '(size:', fileSize.toFixed(2), 'MB)')
+    console.error('File saved to', video_data.path, '(size:', fileSize.toFixed(2), 'MB)')
 
-    console.log('Closing browser')
+    console.error('Closing browser')
     await browser.close()
     xvfb.stopSync()
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,19 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
       "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
     },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -72,6 +85,29 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
+    "cliui": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.1.tgz",
+      "integrity": "sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -90,6 +126,11 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.781568.tgz",
       "integrity": "sha512-9Uqnzy6m6zEStluH9iyJ3iHyaQziFnMnLeC8vK0eN6smiJmIx7+yB64d67C2lH/LZra+5cGscJAJsNXO+MdPMg=="
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -97,6 +138,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "escalade": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig=="
     },
     "extract-zip": {
       "version": "2.0.1",
@@ -135,6 +181,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-stream": {
       "version": "5.2.0",
@@ -184,6 +235,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "locate-path": {
       "version": "5.0.0",
@@ -322,6 +378,11 @@
         "util-deprecate": "^1.0.1"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -344,12 +405,30 @@
         "nan": "^2.13.2"
       }
     },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "requires": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "requires": {
+        "ansi-regex": "^5.0.0"
       }
     },
     "tar-fs": {
@@ -394,6 +473,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -411,6 +500,30 @@
       "requires": {
         "sleep": "6.1.0"
       }
+    },
+    "y18n": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.2.tgz",
+      "integrity": "sha512-CkwaeZw6dQgqgPGeTWKMXCRmMcBgETFlTml1+ZOO+q7kGst8NREJ+eWwFNPVUQ4QGdAaklbqCZHH6Zuep1RjiA=="
+    },
+    "yargs": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+      "requires": {
+        "cliui": "^7.0.0",
+        "escalade": "^3.0.2",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.1",
+        "yargs-parser": "^20.0.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,9 +48,9 @@
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.1",
   "description": "Capture all automated actions in a browser and export as a video",
   "scripts": {
-    "example": "node export.js http://tobiasahlin.com/spinkit/ spinner.webm"
+    "example": "node export.js http://tobiasahlin.com/spinkit/ spinner.webm",
+    "copy-extension": "cp -a ./chrome-extensions/screen-recording ./recorder-extension",
+    "install-manifest-key": "cp .manifest.json.key manifest.json.new && tail -n +2 ./chrome-extensions/screen-recording/manifest.json >> manifest.json.new && mv manifest.json.new ./recorder-extension/manifest.json",
+    "install-extension": "git submodule init && git submodule update && npm run copy-extension && npm run install-manifest-key"
   },
   "keywords": [
     "record",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "puppeteer-core": "^5.2.1",
-    "xvfb": "^0.3.0"
+    "xvfb": "^0.3.0",
+    "yargs": "^16.0.3"
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 chown node:node /home/node/Downloads
-exec gosu node:node node export.js "$@"
+exec gosu node:node node --unhandled-rejections=strict export.js "$@"


### PR DESCRIPTION
Basically, these folks have fixes in place to fix the timing issue.

Is it possible to port some of their changes so we don't see the issue either?

Currently, the issue is that if I want an 8 second video, puppetcam delivers a 9 second video. This is because it delivers an 8.x seconds video, which ffmpeg rounds off. This is fine for most cases, but we'd like some precision dammit!

https://github.com/apicore-engineering/puppetcam/commit/dc1096960824a94e5f21cb30925bda49443f8fc8